### PR TITLE
Add option to embed an icon to generated QR Codes

### DIFF
--- a/generatePlayCards.py
+++ b/generatePlayCards.py
@@ -3,31 +3,40 @@ from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import cm
 import qrcode
+from qrcode.image.styledpil import StyledPilImage
 import hashlib
 import argparse
 import textwrap
+import os
 
-def generate_qr_code(url, file_path):
+#icon_path = None;
+
+def generate_qr_code(url, file_path, icon_path):
     qr = qrcode.QRCode(
         version=1,
-        error_correction=qrcode.constants.ERROR_CORRECT_L,
+        error_correction=qrcode.constants.ERROR_CORRECT_Q,
         box_size=10,
         border=4,
     )
     qr.add_data(url)
     qr.make(fit=True)
-    img = qr.make_image(fill_color="black", back_color="white")
+    if icon_path is None:
+        img = qr.make_image(fill_color="black", back_color="white")
+    else:
+        img = qr.make_image(image_factory=StyledPilImage, embeded_image_path=icon_path)
+        #img = qr.make_image(fill_color="black", back_color="white")
     img.save(file_path)
 
-def add_qr_code_with_border(c, url, position, box_size):
+def add_qr_code_with_border(c, url, position, box_size, icon_path):
     hash_object = hashlib.sha256(url.encode())
     hex_dig = hash_object.hexdigest()
 
     qr_code_path = f"qr_{hex_dig}.png"  # Unique path for each QR code
-    generate_qr_code(url, qr_code_path)
+    generate_qr_code(url, qr_code_path, icon_path)
     x, y = position
     c.drawImage(qr_code_path, x, y, width=box_size, height=box_size)
     c.rect(x, y, box_size, box_size)
+    os.remove(qr_code_path)
 
 def add_text_box(c, info, position, box_size):
     x, y = position
@@ -67,7 +76,7 @@ def add_text_box(c, info, position, box_size):
 
     c.rect(x, y, box_size, box_size)
 
-def main(csv_file_path, output_pdf_path):
+def main(csv_file_path, output_pdf_path, icon_path=None):
     data = pd.read_csv(csv_file_path)
     data = data.applymap(lambda x: x.strip() if isinstance(x, str) else x) # Remove leading and trailing whitespaces
 
@@ -89,7 +98,7 @@ def main(csv_file_path, output_pdf_path):
             row_index = position_index // boxes_per_row
             x = hpageindent + (column_index * box_size)
             y = page_height - vpageindent - (row_index + 1) * box_size
-            add_qr_code_with_border(c, row['URL'], (x, y), box_size)
+            add_qr_code_with_border(c, row['URL'], (x, y), box_size, icon_path)
 
         c.showPage()
 
@@ -111,6 +120,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("csv_file", help="Path to the CSV file")
     parser.add_argument("output_pdf", help="Path to the output PDF file")
+    parser.add_argument("--icon", help="path to icon to embedd to QR Code", required = False)
     args = parser.parse_args()
-
-    main(args.csv_file, args.output_pdf)
+    main(args.csv_file, args.output_pdf, args.icon)

--- a/generatePlayCards.py
+++ b/generatePlayCards.py
@@ -31,7 +31,7 @@ def add_qr_code_with_border(c, url, position, box_size):
 
 def add_text_box(c, info, position, box_size):
     x, y = position
-    text_margin = 5
+    text_margin = 2
     c.setFont("Helvetica", 10)
     artist_text = f"{info['Artist']}"
     title_text = f"{info['Title']}"
@@ -43,8 +43,8 @@ def add_text_box(c, info, position, box_size):
     year_x = x + (box_size - c.stringWidth(year_text, "Helvetica-Bold", 30)) / 2
 
     # Split the text into multiple lines if it doesn't fit in the width
-    artist_lines = textwrap.wrap(artist_text, width=int(len(artist_text) / c.stringWidth(artist_text, "Helvetica", 10) * box_size))
-    title_lines = textwrap.wrap(title_text, width=int(len(title_text) / c.stringWidth(title_text, "Helvetica", 10) * box_size))
+    artist_lines = textwrap.wrap(artist_text, width=int(len(artist_text) / c.stringWidth(artist_text, "Helvetica", 10) * (box_size - text_margin)))
+    title_lines = textwrap.wrap(title_text, width=int(len(title_text) / c.stringWidth(title_text, "Helvetica", 10) * (box_size - text_margin)))
 
     # Calculate the centered position for each line of text
     artist_y = y + box_size - 15

--- a/generatePlayCards.py
+++ b/generatePlayCards.py
@@ -9,7 +9,6 @@ import argparse
 import textwrap
 import os
 
-#icon_path = None;
 
 def generate_qr_code(url, file_path, icon_path):
     qr = qrcode.QRCode(
@@ -24,7 +23,6 @@ def generate_qr_code(url, file_path, icon_path):
         img = qr.make_image(fill_color="black", back_color="white")
     else:
         img = qr.make_image(image_factory=StyledPilImage, embeded_image_path=icon_path)
-        #img = qr.make_image(fill_color="black", back_color="white")
     img.save(file_path)
 
 def add_qr_code_with_border(c, url, position, box_size, icon_path):
@@ -120,6 +118,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("csv_file", help="Path to the CSV file")
     parser.add_argument("output_pdf", help="Path to the output PDF file")
-    parser.add_argument("--icon", help="path to icon to embedd to QR Code", required = False)
+    parser.add_argument("--icon", help="path to icon to embedd to QR Code, should not exeed 300x300px and using transparent background", required = False)
     args = parser.parse_args()
     main(args.csv_file, args.output_pdf, args.icon)


### PR DESCRIPTION
As it might help to distinguish sets of cards or just is a nice add on to have your custom icon i added a feature so you can add an icon to the QR Codes.

`python generatePlayCards.py /mnt/data/bayern1.csv  /mnt/data/out.pdf --icon ./icon.png`

![image](https://github.com/andygruber/songseeker-card-generator/assets/2188062/a09dc95c-6c28-4d5e-ad9c-d81ad02be9b3)
